### PR TITLE
fix rounding issue

### DIFF
--- a/ArtifactsBot.Services/ArtifactsService.Simulator.cs
+++ b/ArtifactsBot.Services/ArtifactsService.Simulator.cs
@@ -86,7 +86,7 @@ public partial class ArtifactsService
     /// <summary>
     /// Round to the nearest int. Values ending in .5 always round up. This is the rounding logic used by the game.
     /// </summary>
-    public static int Round(double value) => (int)(value + 0.5);
+    public static int Round(double value) => (int)(Math.Round(value + 0.000_0001)); // the magic number is small epsilon to make 0.5 values round up
 
     public static CharacterStats GetCharacterStats(IEnumerable<ItemSchema> characterEquipment, int characterLevel)
     {


### PR DESCRIPTION
https://github.com/chimermc/ArtifactsBot/blob/a9e0c3ff45a044fec536a4f2d8b74edb40bca77f/ArtifactsBot.Services/ArtifactsService.Simulator.cs#L89

Adding a `0.5` before rounding just moves the issue happening from `*.5` to `*.0`.
Here's a some samples to compare `Math.round`, the `current solution` and my `proposed` ones:
```C#
Console.WriteLine("Normal 0.5 rounding:");
Console.WriteLine("0.0: " + Math.Round(0.0));
Console.WriteLine("0.5: " + Math.Round(0.5));
Console.WriteLine("1.0: " + Math.Round(1.0));
Console.WriteLine("1.5: " + Math.Round(1.5));
Console.WriteLine("2.0: " + Math.Round(2.0));
Console.WriteLine("2.5: " + Math.Round(2.5));
Console.WriteLine("3.0: " + Math.Round(3.0));
Console.WriteLine("3.5: " + Math.Round(3.5));
Console.WriteLine("0.5 rounding adding a 0.5 offset:");
float offset = 0.5f;
Console.WriteLine("0.0: " + Math.Round(0.0 + offset));
Console.WriteLine("0.5: " + Math.Round(0.5 + offset));
Console.WriteLine("1.0: " + Math.Round(1.0 + offset));
Console.WriteLine("1.5: " + Math.Round(1.5 + offset));
Console.WriteLine("2.0: " + Math.Round(2.0 + offset));
Console.WriteLine("2.5: " + Math.Round(2.5 + offset));
Console.WriteLine("3.0: " + Math.Round(3.0 + offset));
Console.WriteLine("3.5: " + Math.Round(3.5 + offset));
float epsilon = 0.000_001f;
Console.WriteLine("0.5 rounding adding a 1/10e6 offset");
Console.WriteLine("0.0: " + Math.Round(0.0 + epsilon));
Console.WriteLine("0.5: " + Math.Round(0.5 + epsilon));
Console.WriteLine("1.0: " + Math.Round(1.0 + epsilon));
Console.WriteLine("1.5: " + Math.Round(1.5 + epsilon));
Console.WriteLine("2.0: " + Math.Round(2.0 + epsilon));
Console.WriteLine("2.5: " + Math.Round(2.5 + epsilon));
Console.WriteLine("3.0: " + Math.Round(3.0 + epsilon));
Console.WriteLine("3.5: " + Math.Round(3.5 + epsilon));
```

Output:
```log
Normal 0.5 rounding:
0.0: 0
0.5: 0
1.0: 1
1.5: 2
2.0: 2
2.5: 2
3.0: 3
3.5: 4
0.5 rounding adding a 0.5 offset:
0.0: 0
0.5: 1
1.0: 2
1.5: 2
2.0: 2
2.5: 3
3.0: 4
3.5: 4
0.5 rounding adding a 1/10e6 offset
0.0: 0
0.5: 1
1.0: 1
1.5: 2
2.0: 2
2.5: 3
3.0: 3
3.5: 4
```
Notice how in the first tow examples odds values appear 1 time and even appear 3 times in sequences.